### PR TITLE
fix: correct keep_temp option type

### DIFF
--- a/pantera.R
+++ b/pantera.R
@@ -75,7 +75,7 @@ spec <- matrix(
     "min_edge",           "z", 1, "integer",
     "rep_factor",         "f", 1, "integer",
     "dual",               "d", 0, "logical",
-    "keep_temp",          "t", 0, "loginal",
+    "keep_temp",          "t", 0, "logical",
     "help",               "h", 0, "logical"
   ),
   byrow = TRUE,


### PR DESCRIPTION
## Summary
- Correct the `keep_temp` CLI option type from `loginal` to `logical`.
- This fixes the invalid mode reported by `getopt` for the `-t` / `keep_temp` flag.

Fixes #10.

## Testing
- `rg -n "loginal|keep_temp.*logical" pantera.R`
- `git diff --check`

`Rscript` was not available in my local environment, so I could not run an R parse check.

## AI disclosure
This pull request was prepared with assistance from OpenAI Codex.